### PR TITLE
[NODE-1107] Test only passes filter if every filter returns true

### DIFF
--- a/lib/metamocha.js
+++ b/lib/metamocha.js
@@ -103,7 +103,7 @@ Metamocha.prototype.applyFilters = function() {
 
   rootSuite.suites.forEach(function(suite) {
     suite.tests = suite.tests.filter(function(test) {
-      return self.filters.some(function(filterObj) {
+      return self.filters.every(function(filterObj) {
         return filterObj.filter(test);
       });
     });


### PR DESCRIPTION
@mbroadst this is a one word change, but kind of comes with an implicit logic shift. Now, filters will have to be constructed such that if a test **doesn't have the relevant metadata field** or **has the relevant metadata field and the correct value**, then the test will pass the filter and be included in the run. Otherwise, the test won't be included.

Also, TIL the filters in core are, technically speaking, "backwards" (the boolean check is for whether a test should be excluded rather than whether it should be included)