### PR TITLE
fix(filters): allow inherited properties for filter's beforeStart

### DIFF
--- a/lib/metadata_ui.js
+++ b/lib/metadata_ui.js
@@ -8,9 +8,9 @@ var Mocha = require('mocha'),
     Test = require('mocha/lib/test');
 
 /**
- * This UI is identical to the BDD interface, but with the addition of 
+ * This UI is identical to the BDD interface, but with the addition of
  * allowing tests and suites to contain metadata
- * https://github.com/mochajs/mocha/blob/master/lib/interfaces/bdd.js 
+ * https://github.com/mochajs/mocha/blob/master/lib/interfaces/bdd.js
  */
 module.exports = Mocha.interfaces.metadata_ui = function(suite) {
   var suites = [suite];
@@ -25,8 +25,8 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
     context.run = mocha.options.delay && common.runWithSuite(suite);
 
     /**
-     * Parse arguments for suite and test functions 
-     */ 
+     * Parse arguments for suite and test functions
+     */
     var _parseArgs = function(args) {
       var testData = {};
       if (typeof args[0] !== 'string') {

--- a/lib/metamocha.js
+++ b/lib/metamocha.js
@@ -116,7 +116,7 @@ MetaMocha.prototype.run = function(configuration, done) {
 
   if (self.filters.length) {
     self.filters.forEach(function(filter) {
-      if (filter.hasOwnProperty('beforeStart')) {
+      if (typeof filter.beforeStart === 'function') {
         filter.beforeStart(configuration, callback);
       } else {
         callback();


### PR DESCRIPTION
If a filter is implemented using ES6 Classes, filter functions
like "beforeStart" might be inherited properties. This fix
allows those properties to be accessed